### PR TITLE
Added warning messages on plugins screen

### DIFF
--- a/TazUOLauncher/Windows/ProfileEditorWindow.axaml
+++ b/TazUOLauncher/Windows/ProfileEditorWindow.axaml
@@ -68,7 +68,7 @@
 
                 <TabItem Header="Plugins">
                     <Grid RowDefinitions="Auto, Auto, *" ColumnDefinitions="*, *" Margin="0, 5, 0, 5">
-						<TextBlock Grid.Row="0"  Grid.ColumnSpan="2" Margin="5, 0, 5, 5" Foreground="Red" FontWeight="Bold" TextWrapping="Wrap" 
+						<TextBlock x:Name="ModernTazUOPluginWarning" IsVisible="False" Grid.Row="0"  Grid.ColumnSpan="2" Margin="5, 0, 5, 5" Foreground="Red" FontWeight="Bold" TextWrapping="Wrap" 
 								   Text="Modern TazUO only supports .NET 9 compatible plugins. Use Legacy TazUO if you are wanting to use legacy plugins such as Razor. You can change your TazUO version by selecting the Update Channel in the TazUO Launcher menu" />
 						
                         <Button Click="AddPluginClicked" Margin="5, 5, 5, 5" Grid.Row="1" Grid.Column="0">Add</Button>

--- a/TazUOLauncher/Windows/ProfileEditorWindow.axaml
+++ b/TazUOLauncher/Windows/ProfileEditorWindow.axaml
@@ -67,11 +67,14 @@
                 </TabItem>
 
                 <TabItem Header="Plugins">
-                    <Grid RowDefinitions="Auto, *" ColumnDefinitions="*, *" Margin="0, 5, 0, 5">
-                        <Button Click="AddPluginClicked" Margin="5, 5, 5, 5">Add</Button>
-                        <Button Click="PluginRemoveClicked" Margin="5, 5, 5, 5" Grid.Column="1">Remove</Button>
+                    <Grid RowDefinitions="Auto, Auto, *" ColumnDefinitions="*, *" Margin="0, 5, 0, 5">
+						<TextBlock Grid.Row="0"  Grid.ColumnSpan="2" Margin="5, 0, 5, 5" Foreground="Red" FontWeight="Bold" TextWrapping="Wrap" 
+								   Text="Modern TazUO only supports .NET 9 compatible plugins. Use Legacy TazUO if you are wanting to use legacy plugins such as Razor. You can change your TazUO version by selecting the Update Channel in the TazUO Launcher menu" />
+						
+                        <Button Click="AddPluginClicked" Margin="5, 5, 5, 5" Grid.Row="1" Grid.Column="0">Add</Button>
+                        <Button Click="PluginRemoveClicked" Margin="5, 5, 5, 5" Grid.Row="1" Grid.Column="1">Remove</Button>
 
-                        <ListBox x:Name="EntryPluginList" ItemsSource="{Binding Plugins}" Grid.Row="1" Grid.ColumnSpan="2"/>
+                        <ListBox x:Name="EntryPluginList" ItemsSource="{Binding Plugins}" Grid.Row="2" Grid.ColumnSpan="2"/>
                     </Grid>
                 </TabItem>
 

--- a/TazUOLauncher/Windows/ProfileEditorWindow.axaml.cs
+++ b/TazUOLauncher/Windows/ProfileEditorWindow.axaml.cs
@@ -29,6 +29,9 @@ public partial class ProfileEditorWindow : Window
             if (!string.IsNullOrEmpty(EntryAccountName.Text))
                 EntrySavePass.IsChecked = true;
         };
+
+        bool isModernTazUO = LauncherSettings.GetLauncherSaveFile.DownloadChannel == ReleaseChannel.MAIN || LauncherSettings.GetLauncherSaveFile.DownloadChannel == ReleaseChannel.DEV;
+        ModernTazUOPluginWarning.IsVisible = isModernTazUO;
     }
 
     public void LocateUOFolderClicked(object s, RoutedEventArgs args)


### PR DESCRIPTION
<img width="1600" height="950" alt="image" src="https://github.com/user-attachments/assets/a5286b37-2937-4d6b-a924-670f355fd54c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a prominent red compatibility warning at the top of the Plugins tab, shown for modern release channels.
  * Reorganized the Plugins tab layout: warning appears above controls, Add/Remove buttons moved for clearer access, and the plugin list repositioned for improved readability and flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->