### PR TITLE
ci(launcher): Add tag-based release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  PROJ: "TazUOLauncher/TazUOLauncher.csproj"
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            rid: win-x64
+          - os: ubuntu-latest
+            rid: linux-x64
+          - os: macos-latest
+            rid: osx-arm64
+          - os: macos-15-intel
+            rid: osx-x64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Publish
+        run: dotnet publish ${{ env.PROJ }} -c Release -r ${{ matrix.rid }} --self-contained -o publish
+
+      - name: Set executable permission
+        if: runner.os != 'Windows'
+        run: chmod +x publish/*
+
+      - name: Zip output
+        uses: thedoctor0/zip-release@master
+        with:
+          type: zip
+          directory: publish
+          filename: TUO-Launcher-${{ matrix.rid }}.zip
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: TUO-Launcher-${{ matrix.rid }}
+          path: publish/TUO-Launcher-${{ matrix.rid }}.zip
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: artifacts/*/TUO-Launcher-*.zip


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` triggered on `v*` tag pushes
- Builds the launcher for 4 platforms: win-x64, linux-x64, osx-arm64, osx-x64
- Creates a GitHub Release with all platform zip files via `softprops/action-gh-release@v2`

## Details
- Matrix strategy with explicit OS/RID pairs: windows-latest, ubuntu-latest, macos-latest (ARM64), macos-15-intel (x64)
- Each build runs `dotnet publish` with `--self-contained` and platform-specific RID
- Artifacts are uploaded per-platform, then a separate release job downloads all and creates the release
- Uses `generate_release_notes: true` for automatic release notes

## Test plan
- [ ] Verify YAML is valid
- [ ] Merge and push a `v0.1.0` tag to trigger the workflow
- [ ] Verify all 4 platform builds succeed
- [ ] Verify GitHub Release is created with 4 zip files

Refs: TazUo-mol-oanw

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated release workflow now builds and publishes pre-compiled binaries for Windows, Linux, and macOS when versions are tagged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->