### PR TITLE
Fix launcher self-update on Windows and macOS

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -137,6 +137,7 @@ jobs:
           
       - name: Remove old Release
         if: ${{ strategy.job-index == 0 }}
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ env.TAG_NAME }}

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -40,7 +40,7 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.ref_name }}
 
@@ -63,7 +63,7 @@ jobs:
           git push origin v${{ env.VERSION }}
 
       - name: Setup .NET 9
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 9.0.x
 
@@ -134,19 +134,23 @@ jobs:
       - name: Echo release notes
         shell: bash
         run: echo "${{ steps.release_notes.outputs.RELEASE_NOTES }}"
-
+          
       - name: Remove old Release
-        uses: dev-drprasad/delete-tag-and-release@v0.2.1
         if: ${{ strategy.job-index == 0 }}
-        with:
-          delete_release: true
-          tag_name: ${{ env.TAG_NAME }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ env.TAG_NAME }}
+        run: |
+          # Delete the release; --yes skips the confirmation prompt
+          # If the release doesn't exist, we use '|| true' to prevent the workflow from failing
+          gh release delete "$TAG" --yes || echo "Release not found, skipping."
+
+          # Delete the tag from the remote repository
+          git push --delete origin "$TAG" || echo "Tag not found, skipping."
 
       - name: Upload Release
         if: ${{ strategy.job-index == 0 }}
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@v1.21.0
         with:
           artifacts: "${{ env.OUTPUT_PATH }}/${{ env.RID }}/${{ env.ZIP_NAME }}.${{ env.RID }}.zip"
           name: "v${{ env.VERSION }}"
@@ -159,6 +163,7 @@ jobs:
           makeLatest: true
           allowUpdates: true
           prerelease: false
+          draft: false
           tag: ${{ env.TAG_NAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -177,5 +182,6 @@ jobs:
           allowUpdates: true
           prerelease: false
           replacesArtifacts: false
+          draft: false
           tag: ${{ env.TAG_NAME }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # TUO-Launcher
-A launcher for TazUO  
-
-This branch is in progress, being rebuilt for cross platform support and improved code.
+A launcher for [TazUO](https://github.com/PlayTazUO/TazUO). Easily play multiple shards, different accounts, different UO versions, all while staying up to date with TazUO.
 
 
 
 ## Installation  
-Download the latest release, unzip it and open `TazUO Launcher.exe`!
+Download the latest release, unzip it and open `TazUO Launcher`!

--- a/TazUOLauncher/Constants.cs
+++ b/TazUOLauncher/Constants.cs
@@ -18,4 +18,5 @@ internal static class CONSTANTS {
     public const string ZIP_STARTS_WITH = "TazUO";
     public const string CLASSIC_EXE_NAME = "ClassicUO";
     public const string NATIVE_EXECUTABLE_NAME = "TazUO";
+    public const string PROCESS_NAME = "TazUO";
 }

--- a/TazUOLauncher/TazUOLauncher.csproj
+++ b/TazUOLauncher/TazUOLauncher.csproj
@@ -6,8 +6,8 @@
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <AssemblyVersion>2.6.15.0</AssemblyVersion>
-    <FileVersion>2.6.15.0</FileVersion>
+    <AssemblyVersion>2.6.16.0</AssemblyVersion>
+    <FileVersion>2.6.16.0</FileVersion>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
     <ApplicationIcon>Resources\icon.ico</ApplicationIcon>

--- a/TazUOLauncher/Utility/UpdateHelper.cs
+++ b/TazUOLauncher/Utility/UpdateHelper.cs
@@ -172,15 +172,9 @@ internal static class UpdateHelper
     /// <param name="downloadProgress"></param>
     /// <param name="onCompleted"></param>
     /// <param name="parentWindow"></param>
-    public static async void DownloadAndInstallZip(ReleaseChannel channel, DownloadProgress downloadProgress, Action onCompleted, Window? parentWindow = null)
+    public static async void DownloadAndInstallZip(ReleaseChannel channel, DownloadProgress downloadProgress, Action onCompleted)
     {
         if (!HaveData(channel)) return;
-
-        if (parentWindow != null && !await ProcessRunningShouldWeProceed(parentWindow))
-        {
-            onCompleted?.Invoke();
-            return;
-        }
 
         GitHubReleaseData releaseData = ReleaseData[channel];
 

--- a/TazUOLauncher/Utility/UpdateHelper.cs
+++ b/TazUOLauncher/Utility/UpdateHelper.cs
@@ -176,27 +176,10 @@ internal static class UpdateHelper
     {
         if (!HaveData(channel)) return;
 
-        if (Process.GetProcessesByName("TazUO").Length > 0)
+        if (parentWindow != null && !await ProcessRunningShouldWeProceed(parentWindow))
         {
-            if (parentWindow != null)
-            {
-                bool proceed = await Utility.ShowConfirmationDialog(
-                    parentWindow,
-                    "TazUO is Running",
-                    "TazUO appears to be running. Updating while the client is running may cause issues.\n\nDo you want to proceed with the update anyway?"
-                );
-
-                if (!proceed)
-                {
-                    onCompleted();
-                    return;
-                }
-            }
-            else
-            {
-                onCompleted();
-                return;
-            }
+            onCompleted?.Invoke();
+            return;
         }
 
         GitHubReleaseData releaseData = ReleaseData[channel];
@@ -260,5 +243,19 @@ internal static class UpdateHelper
             
             onCompleted?.Invoke();
         });
+    }
+
+    public static async Task<bool> ProcessRunningShouldWeProceed(Window parentWindow)
+    {
+        if (Process.GetProcessesByName(CONSTANTS.PROCESS_NAME).Length > 0)
+        {
+            return await Utility.ShowConfirmationDialog(
+                parentWindow,
+                $"{CONSTANTS.PROCESS_NAME} is running",
+                $"{CONSTANTS.PROCESS_NAME} appears to be running. Updating while running may cause issues.\n\nDo you want to proceed with the update anyway?"
+            );
+        }
+        
+        return true;
     }
 }

--- a/TazUOLauncher/Windows/MainWindow.axaml.cs
+++ b/TazUOLauncher/Windows/MainWindow.axaml.cs
@@ -191,7 +191,6 @@ public partial class MainWindow : Window
 
         if (nextDownloadType != ReleaseChannel.LAUNCHER && !await UpdateHelper.ProcessRunningShouldWeProceed(this))
         {
-            DoChecksAsync();
             return;
         }
 
@@ -216,7 +215,7 @@ public partial class MainWindow : Window
             ClientExistsChecks();
             ClientUpdateChecks();
             HandleUpdates();
-        }, this);
+        });
     }
     private void OpenEditProfiles()
     {

--- a/TazUOLauncher/Windows/MainWindow.axaml.cs
+++ b/TazUOLauncher/Windows/MainWindow.axaml.cs
@@ -368,16 +368,24 @@ public partial class MainWindow : Window
 
         MigrateOldUpdater();
         
-        // Spawn updater and exit
-        string launcherExe = Process.GetCurrentProcess().MainModule?.FileName ?? string.Empty;
+        // Spawn updater and exit.
+        // Use absolute paths for all arguments so the updater operates on the correct locations
+        // regardless of the working directory it inherits.
+        string? rawExe = Process.GetCurrentProcess().MainModule?.FileName;
+        string launcherExe = string.IsNullOrEmpty(rawExe) ? string.Empty : Path.GetFullPath(rawExe);
+        string absoluteZipPath = Path.GetFullPath(zipPath);
+        string absoluteLauncherPath = Path.GetFullPath(PathHelper.LauncherPath);
         int pid = Environment.ProcessId;
 
+        // UseShellExecute=true is required on Windows: it uses ShellExecuteEx which creates the
+        // updater process outside the launcher's Job Object. Without this the updater is killed
+        // when the launcher (parent) exits because child processes inherit the Job Object.
         Process.Start(new ProcessStartInfo(
             updaterPath,
-            $"{pid} \"{zipPath}\" \"{PathHelper.LauncherPath}\" \"{launcherExe}\"")
+            $"{pid} \"{absoluteZipPath}\" \"{absoluteLauncherPath}\" \"{launcherExe}\"")
         {
             WorkingDirectory = tPath.FullName,
-            UseShellExecute = false
+            UseShellExecute = true
         });
 
         ((IClassicDesktopStyleApplicationLifetime)Application.Current!.ApplicationLifetime!).Shutdown();

--- a/TazUOLauncher/Windows/MainWindow.axaml.cs
+++ b/TazUOLauncher/Windows/MainWindow.axaml.cs
@@ -243,6 +243,8 @@ public partial class MainWindow : Window
             "This is safe, your settings and profile data are saved, but if you store other files in the same TazUO folder, they will be removed.",
             b =>
             {
+                if (!b) return;
+                
                 Dispatcher.UIThread.Invoke(() =>
                 {
                     viewModel.MainChannelSelected = true;
@@ -264,6 +266,8 @@ public partial class MainWindow : Window
             "This is safe, your settings and profile data are saved, but if you store other files in the same TazUO folder, they will be removed.",
             b =>
             {
+                if (!b) return;
+                
                 Dispatcher.UIThread.Invoke(() =>
                 {
                     viewModel.DevChannelSelected = true;
@@ -286,6 +290,8 @@ public partial class MainWindow : Window
             {
                 Dispatcher.UIThread.Invoke(() =>
                 {
+                    if (!b) return;
+                    
                     viewModel.DevChannelSelected = false;
                     viewModel.MainChannelSelected = false;
                     viewModel.LegacyChannelSelected = true;

--- a/TazUOLauncher/Windows/MainWindow.axaml.cs
+++ b/TazUOLauncher/Windows/MainWindow.axaml.cs
@@ -374,18 +374,22 @@ public partial class MainWindow : Window
         string? rawExe = Process.GetCurrentProcess().MainModule?.FileName;
         string launcherExe = string.IsNullOrEmpty(rawExe) ? string.Empty : Path.GetFullPath(rawExe);
         string absoluteZipPath = Path.GetFullPath(zipPath);
-        string absoluteLauncherPath = Path.GetFullPath(PathHelper.LauncherPath);
+        // Trim any trailing directory separator: AppDomain.CurrentDomain.BaseDirectory always ends
+        // with one, and a path like "C:\foo\bar\" inside quotes makes the \" look like an escaped
+        // quote to Windows argument parsing, breaking the argument boundary.
+        string absoluteLauncherPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(PathHelper.LauncherPath));
         int pid = Environment.ProcessId;
 
-        // UseShellExecute=true is required on Windows: it uses ShellExecuteEx which creates the
-        // updater process outside the launcher's Job Object. Without this the updater is killed
-        // when the launcher (parent) exits because child processes inherit the Job Object.
+        // On Windows, UseShellExecute=true (ShellExecuteEx) creates the updater outside the
+        // launcher's Job Object so it survives the launcher exiting.
+        // On macOS/Linux, UseShellExecute=true routes through open/xdg-open which cannot launch
+        // raw binaries — use false to exec directly.
         Process.Start(new ProcessStartInfo(
             updaterPath,
             $"{pid} \"{absoluteZipPath}\" \"{absoluteLauncherPath}\" \"{launcherExe}\"")
         {
             WorkingDirectory = tPath.FullName,
-            UseShellExecute = true
+            UseShellExecute = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
         });
 
         ((IClassicDesktopStyleApplicationLifetime)Application.Current!.ApplicationLifetime!).Shutdown();

--- a/TazUOLauncher/Windows/MainWindow.axaml.cs
+++ b/TazUOLauncher/Windows/MainWindow.axaml.cs
@@ -389,7 +389,7 @@ public partial class MainWindow : Window
             $"{pid} \"{absoluteZipPath}\" \"{absoluteLauncherPath}\" \"{launcherExe}\"")
         {
             WorkingDirectory = tPath.FullName,
-            UseShellExecute = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            UseShellExecute = PlatformHelper.IsWindows
         });
 
         ((IClassicDesktopStyleApplicationLifetime)Application.Current!.ApplicationLifetime!).Shutdown();

--- a/TazUOLauncher/Windows/MainWindow.axaml.cs
+++ b/TazUOLauncher/Windows/MainWindow.axaml.cs
@@ -176,29 +176,24 @@ public partial class MainWindow : Window
         if (nextDownloadType == ReleaseChannel.INVALID) return false;
 
         if (clientStatus <= ClientStatus.DOWNLOAD_IN_PROGRESS) return false;
-
-        if (Process.GetProcessesByName("TazUO").Length > 0)
-        {
-            bool proceed = await Utility.ShowConfirmationDialog(
-                this,
-                "TazUO is Running",
-                "TazUO appears to be running. Updating while the client is running may cause issues.\n\nDo you want to proceed with the update anyway?"
-            );
-
-            if (!proceed) return false;
-        }
-
+        
         if (nextDownloadType > ReleaseChannel.INVALID && LauncherSettings.GetLauncherSaveFile.AutoDownloadUpdates)
         {
-            DoNextDownload();
+            await DoNextDownload();
             return true;
         }
 
         return false;
     }
-    private void DoNextDownload()
+    private async Task DoNextDownload()
     {
         if (nextDownloadType == ReleaseChannel.INVALID || clientStatus == ClientStatus.DOWNLOAD_IN_PROGRESS) return;
+
+        if (nextDownloadType != ReleaseChannel.LAUNCHER && !await UpdateHelper.ProcessRunningShouldWeProceed(this))
+        {
+            DoChecksAsync();
+            return;
+        }
 
         viewModel.ShowDownloadAvailableButton = false;
         var prog = new DownloadProgress();
@@ -243,31 +238,62 @@ public partial class MainWindow : Window
     {
         if (LauncherSettings.GetLauncherSaveFile.DownloadChannel == ReleaseChannel.MAIN) return;
         
-        viewModel.MainChannelSelected = true;
-        viewModel.DevChannelSelected = false;
-        viewModel.LegacyChannelSelected = false;
-        LauncherSettings.GetLauncherSaveFile.DownloadChannel = ReleaseChannel.MAIN;
-        RecheckAfterChannelUpdated();
+        _ = Utility.ShowConfirmationDialog(this, 
+            "Are you sure?", 
+            "Changing channels will remove the current installation to ensure we have the correct files.\n" +
+            "This is safe, your settings and profile data are saved, but if you store other files in the same TazUO folder, they will be removed.",
+            b =>
+            {
+                Dispatcher.UIThread.Invoke(() =>
+                {
+                    viewModel.MainChannelSelected = true;
+                    viewModel.DevChannelSelected = false;
+                    viewModel.LegacyChannelSelected = false;
+                    LauncherSettings.GetLauncherSaveFile.DownloadChannel = ReleaseChannel.MAIN;
+
+                    RecheckAfterChannelUpdated();
+                });
+            });
     }
     public void SetDevChannelClicked(object sender, RoutedEventArgs args)
     {
         if (LauncherSettings.GetLauncherSaveFile.DownloadChannel == ReleaseChannel.DEV) return;
         
-        viewModel.DevChannelSelected = true;
-        viewModel.MainChannelSelected = false;
-        viewModel.LegacyChannelSelected = false;
-        LauncherSettings.GetLauncherSaveFile.DownloadChannel = ReleaseChannel.DEV;
-        RecheckAfterChannelUpdated();
+        _ = Utility.ShowConfirmationDialog(this, 
+            "Are you sure?", 
+            "Changing channels will remove the current installation to ensure we have the correct files.\n" +
+            "This is safe, your settings and profile data are saved, but if you store other files in the same TazUO folder, they will be removed.",
+            b =>
+            {
+                Dispatcher.UIThread.Invoke(() =>
+                {
+                    viewModel.DevChannelSelected = true;
+                    viewModel.MainChannelSelected = false;
+                    viewModel.LegacyChannelSelected = false;
+                    LauncherSettings.GetLauncherSaveFile.DownloadChannel = ReleaseChannel.DEV;
+                    RecheckAfterChannelUpdated();
+                });
+            });
     }
     public void SetLegacyChannelClicked(object sender, RoutedEventArgs args)
     {
         if (LauncherSettings.GetLauncherSaveFile.DownloadChannel == ReleaseChannel.NET472) return;
         
-        viewModel.DevChannelSelected = false;
-        viewModel.MainChannelSelected = false;
-        viewModel.LegacyChannelSelected = true;
-        LauncherSettings.GetLauncherSaveFile.DownloadChannel = ReleaseChannel.NET472;
-        RecheckAfterChannelUpdated();
+        _ = Utility.ShowConfirmationDialog(this, 
+            "Are you sure?", 
+            "Changing channels will remove the current installation to ensure we have the correct files.\n" +
+            "This is safe, your settings and profile data are saved, but if you store other files in the same TazUO folder, they will be removed.",
+            b =>
+            {
+                Dispatcher.UIThread.Invoke(() =>
+                {
+                    viewModel.DevChannelSelected = false;
+                    viewModel.MainChannelSelected = false;
+                    viewModel.LegacyChannelSelected = true;
+                    LauncherSettings.GetLauncherSaveFile.DownloadChannel = ReleaseChannel.NET472;
+                    RecheckAfterChannelUpdated();
+                });
+            });
     }
 
     private async void RecheckAfterChannelUpdated()
@@ -295,7 +321,7 @@ public partial class MainWindow : Window
     }
     public void DownloadButtonClicked(object sender, RoutedEventArgs args)
     {
-        DoNextDownload();
+        _ = DoNextDownload();
     }
     public void ProfileSelectionChanged(object sender, SelectionChangedEventArgs args)
     {

--- a/TazUOLauncher/Windows/ProfileEditorWindow.axaml
+++ b/TazUOLauncher/Windows/ProfileEditorWindow.axaml
@@ -4,6 +4,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:vm="using:TazUOLauncher"
     xmlns:tazUoLauncher="clr-namespace:TazUOLauncher"
+    xmlns:sys="clr-namespace:System;assembly=System.Runtime"
     mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
     Width="800" Height="450" CanResize="False"
     x:DataType="vm:ProfileEditorViewModel"
@@ -74,7 +75,13 @@
                         <Button Click="AddPluginClicked" Margin="5, 5, 5, 5" Grid.Row="1" Grid.Column="0">Add</Button>
                         <Button Click="PluginRemoveClicked" Margin="5, 5, 5, 5" Grid.Row="1" Grid.Column="1">Remove</Button>
 
-                        <ListBox x:Name="EntryPluginList" ItemsSource="{Binding Plugins}" Grid.Row="2" Grid.ColumnSpan="2"/>
+                        <ListBox x:Name="EntryPluginList" ItemsSource="{Binding Plugins}" Grid.Row="2" Grid.ColumnSpan="2">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate x:DataType="sys:String">
+                                    <TextBlock Text="{Binding}" ToolTip.Tip="{Binding}"/>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
                     </Grid>
                 </TabItem>
 

--- a/TazUOUpdater/Program.cs
+++ b/TazUOUpdater/Program.cs
@@ -5,6 +5,10 @@ using System.IO.Compression;
 using System.Runtime.InteropServices;
 using System.Threading;
 
+Console.Title = "TazUO Updater";
+
+Console.WriteLine("Running TazUO Updater...");
+
 if (args.Length < 4)
 {
     Console.Error.WriteLine("Usage: TazUOUpdater <launcher-pid> <zip-path> <extract-dir> <launcher-exe-path>");
@@ -25,6 +29,7 @@ string launcherExePath = Path.GetFullPath(args[3]);
 // Wait for the launcher to exit
 try
 {
+    Console.WriteLine("Waiting for launcher to fully exit...");
     var proc = Process.GetProcessById(pid);
     if (!proc.WaitForExit(10_000))
     {
@@ -39,6 +44,8 @@ catch (ArgumentException)
 
 // Give the OS a moment to release file handles
 Thread.Sleep(500);
+
+Console.WriteLine("Unzipping launcher update into launcher folder...");
 
 // Extract the update ZIP over the launcher directory
 try
@@ -69,6 +76,7 @@ RunLauncher();
 
 void RunLauncher()
 {
+    Console.WriteLine("Starting launcher...");
     // Restore execute permission on non-Windows
     if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
     {

--- a/TazUOUpdater/Program.cs
+++ b/TazUOUpdater/Program.cs
@@ -18,9 +18,9 @@ if (!int.TryParse(args[0], out pid))
     return 1;
 }
 
-string zipPath = args[1];
-string extractDir = args[2];
-string launcherExePath = args[3];
+string zipPath = Path.GetFullPath(args[1]);
+string extractDir = Path.GetFullPath(args[2]);
+string launcherExePath = Path.GetFullPath(args[3]);
 
 // Wait for the launcher to exit
 try
@@ -83,7 +83,15 @@ void RunLauncher()
     }
     
     // Relaunch the launcher
-    Process.Start(new ProcessStartInfo(launcherExePath) { WorkingDirectory = new FileInfo(launcherExePath).DirectoryName, UseShellExecute = true });
+    string workingDir = Path.GetDirectoryName(launcherExePath) ?? Path.GetFullPath(".");
+    // On Windows, UseShellExecute=true (ShellExecuteEx) works correctly for GUI apps.
+    // On macOS/Linux, UseShellExecute=true routes through the OS file-opener (open/xdg-open)
+    // which cannot launch raw Unix binaries — use false to exec directly.
+    Process.Start(new ProcessStartInfo(launcherExePath)
+    {
+        WorkingDirectory = workingDir,
+        UseShellExecute = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+    });
 }
 
 return 0;


### PR DESCRIPTION
Windows: spawning the updater with UseShellExecute=false caused it to inherit the launcher's Job Object. When the launcher exited the updater was killed before it could apply the update. Changed to UseShellExecute=true (ShellExecuteEx) so the updater runs outside the Job Object and survives.

macOS: UseShellExecute=true in RunLauncher() routes through the OS open command, which cannot launch raw Unix binaries, so the launcher silently never reopened after an update. Changed to UseShellExecute=false on non-Windows to exec the binary directly.

Also ensure all paths passed to the updater (zip, extract dir, launcher exe) and paths received by the updater are resolved via Path.GetFullPath() so relative or ambiguous paths cannot cause files to land in the wrong location.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updater reliably launches using absolute paths and now restarts correctly across platforms.
  * Update/install flow is non-blocking so manual actions no longer freeze the UI.

* **New Features**
  * Updater shows progress/status messages during wait, unzip, and relaunch steps.
  * Update checks now properly detect a running game and prompt before proceeding when needed.

* **UI Improvements**
  * Channel switches now prompt confirmation before changing.
  * Plugins list displays clearer text with tooltips.

* **Documentation**
  * README installation instructions and overview updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->